### PR TITLE
Bump node version to current LTS version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,12 +9,12 @@ inputs:
     required: true
     default: 'default'
   config:
-    description: 'condifuration file'
+    description: 'configuration file'
     required: false
     default: '.github/auto-assigner.yml'
 outputs:
-  time: # output will be available to future steps 
+  time: # output will be available to future steps
     description: 'The message to output'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "JavaScript Action Template",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Node.js v12 GitHub Actions are now deprecated and will soon stop working. This PR will bump the node version to the current LTS version of Node.js (i.e. 16) to address these deprecation warnings.